### PR TITLE
Add sheetify plugin for eyeglass

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,7 @@ build-tool plugin. The following plugins are available:
 
 * [broccoli-eyeglass](https://github.com/sass-eyeglass/broccoli-eyeglass)
 * [ember-cli-eyeglass](https://github.com/sass-eyeglass/ember-cli-eyeglass)
+* [sheetify-eyeglass](https://github.com/scriptollc/sheetify-eyeglass)
 
 
 ## Integrating with other build systems


### PR DESCRIPTION
Sheetify is a css bundler used with browserify that supports plugins and css-as-npm-modules.  This is a plugin that enables the use of eyeglass modules with it.