### PR TITLE
Don't use package.json files to locate a module from the directory structure.

### DIFF
--- a/packages/ember-cli-eyeglass/package.json
+++ b/packages/ember-cli-eyeglass/package.json
@@ -14,7 +14,7 @@
     "lint": "eslint --ext ts --format visualstudio .",
     "lintfix": "eslint --ext ts --fix .",
     "start": "ember serve",
-    "test": "EMBER_CLI_SYSTEM_TEMP=false ember test",
+    "test": "ember test",
     "test:node": "mocha node-tests/**/*-test.js",
     "test:all": "ember try:each"
   },

--- a/packages/eyeglass/src/importers/AssetImporter.ts
+++ b/packages/eyeglass/src/importers/AssetImporter.ts
@@ -1,7 +1,6 @@
 import { existsSync } from "fs";
 import { AsyncImporter } from "node-sass";
 import EyeglassModule from "../modules/EyeglassModule";
-import * as packageUtils from "../util/package";
 import { URI } from "../util/URI";
 import { ImporterFactory } from "./ImporterFactory";
 import ImportUtilities from "./ImportUtilities";
@@ -60,15 +59,11 @@ const AssetImporter: ImporterFactory = function (eyeglass, sass, options, fallba
       });
     } else {
       // if the module name wasn't specified in the import,
-      //  infer it from the origin
+      // infer it from the origin
       if (!moduleName && isRealFile) {
-        let pkg = packageUtils.findNearestPackage(prev);
-        mod = new EyeglassModule({
-          path: pkg
-        });
-
+        mod = eyeglass.modules.findByPath(prev);
         // if it's an eyeglass module...
-        if (mod.isEyeglassModule) {
+        if (mod && mod.isEyeglassModule) {
           // use the module's name
           moduleName = mod.name;
         }

--- a/packages/eyeglass/src/modules/EyeglassModule.ts
+++ b/packages/eyeglass/src/modules/EyeglassModule.ts
@@ -133,6 +133,10 @@ interface IEyeglassModule {
    */
   isEyeglassModule: boolean;
   /**
+   * Whether this is the project root.
+   */
+  isRoot: boolean;
+  /**
    * The version of this module.
    */
   version: string | undefined;
@@ -159,6 +163,7 @@ export default class EyeglassModule implements IEyeglassModule, EyeglassModuleEx
   dependencies: Dict<EyeglassModule>;
   eyeglass: EyeglassModuleOptionsFromPackageJSON;
   isEyeglassModule: boolean;
+  isRoot: boolean;
   name: string;
   path: string;
   rawName: string;
@@ -195,7 +200,8 @@ export default class EyeglassModule implements IEyeglassModule, EyeglassModuleEx
       mod = merge(
         {
           isEyeglassModule: EyeglassModule.isEyeglassModule(pkg.data),
-          inDevelopment: false
+          inDevelopment: false,
+          isRoot
         },
         mod,
         {
@@ -242,6 +248,7 @@ export default class EyeglassModule implements IEyeglassModule, EyeglassModuleEx
     this.rawName = mod.rawName;
     this.version = mod.version;
     this.inDevelopment = mod.inDevelopment;
+    this.isRoot = mod.isRoot;
 
     // merge the module properties into the instance
     merge(this, mod);

--- a/packages/eyeglass/src/modules/EyeglassModules.ts
+++ b/packages/eyeglass/src/modules/EyeglassModules.ts
@@ -212,7 +212,7 @@ export default class EyeglassModules {
       if (mod) {
         return mod;
       }
-      parentLocation = path.resolve(location, "..");
+      parentLocation = path.dirname(location);
     } while (parentLocation != location)
     return null;
   }


### PR DESCRIPTION
This is more efficient because it avoids a lot of filesystem access.

This also works around an issue in ember-cli where package.json files
seem to go missing during the build.