### PR TITLE
Perf instrumentation

### DIFF
--- a/eyeglass.code-workspace
+++ b/eyeglass.code-workspace
@@ -9,5 +9,10 @@
 		{
 			"path": "packages/ember-cli-eyeglass"
 		}
-	]
+	],
+	"settings": {
+		"cSpell.words": [
+			"heimdall"
+		]
+	}
 }

--- a/packages/broccoli-eyeglass/package.json
+++ b/packages/broccoli-eyeglass/package.json
@@ -48,6 +48,7 @@
     "fs-tree-diff": "^1.0.0",
     "glob": "^7.1.2",
     "hash-for-dep": "^1.2.3",
+    "heimdalljs": "^0.2.6",
     "json-stable-stringify": "^1.0.1",
     "lodash.clonedeep": "^4.5.0",
     "lodash.merge": "^4.6.1",

--- a/packages/broccoli-eyeglass/src/index.ts
+++ b/packages/broccoli-eyeglass/src/index.ts
@@ -13,6 +13,7 @@ import Eyeglass = require("eyeglass");
 import * as sass from "node-sass";
 import hashForDep = require("hash-for-dep");
 import { EyeglassOptions } from "eyeglass/lib/util/Options";
+
 type SassImplementation = typeof sass;
 const persistentCacheDebug = debugGenerator("broccoli-eyeglass:persistent-cache");
 const assetImportCacheDebug = debugGenerator("broccoli-eyeglass:asset-import-cache");

--- a/packages/broccoli-eyeglass/tsconfig.json
+++ b/packages/broccoli-eyeglass/tsconfig.json
@@ -25,7 +25,7 @@
       "target": "es5",
       "sourceMap": true,
       "paths": {
-        "node-sass": ["../../eyeglass/@types/node-sass"],
+        "heimdalljs": ["../../eyeglass/src/types/heimdalljs"],
         "*": ["types/*"],
       }
   },

--- a/packages/eyeglass/package.json
+++ b/packages/eyeglass/package.json
@@ -64,6 +64,7 @@
     "@typescript-eslint/eslint-plugin": "^1.2.0",
     "@typescript-eslint/parser": "^1.2.0",
     "eslint": "^5.12.1",
+    "heimdalljs": "^0.2.6",
     "grunt": "^1.0.3",
     "grunt-release": "^0.14.0",
     "handlebars": "^4.0.12",

--- a/packages/eyeglass/src/importers/AssetImporter.ts
+++ b/packages/eyeglass/src/importers/AssetImporter.ts
@@ -19,7 +19,7 @@ interface HasAssets {
 const rAssetsImport = /^(?:([^/]+)\/)?assets$/;
 const AssetImporter: ImporterFactory = function (eyeglass, sass, options, fallbackImporter?: AsyncImporter | Array<AsyncImporter>): AsyncImporter {
 
-  return ImportUtilities.createImporter(function(uri, prev, done) {
+  return ImportUtilities.createImporter("assets", function(uri, prev, done) {
     let importUtils = new ImportUtilities(eyeglass, sass, options, fallbackImporter, this);
 
     let isRealFile = existsSync(prev);

--- a/packages/eyeglass/src/importers/FSImporter.ts
+++ b/packages/eyeglass/src/importers/FSImporter.ts
@@ -7,7 +7,7 @@ import { AsyncImporter } from "node-sass";
 const FSImporter: ImporterFactory = function (eyeglass, sass, options, fallbackImporter): AsyncImporter {
   let fsURI = /^fs\(([-_a-zA-Z][-_a-zA-Z0-9]+)\)$/;
 
-  return ImportUtilities.createImporter(function(uri, prev, done) {
+  return ImportUtilities.createImporter("fs", function(uri, prev, done) {
     let importUtils = new ImportUtilities(eyeglass, sass, options, fallbackImporter, this);
     let match = uri.match(fsURI);
     if (match) {

--- a/packages/eyeglass/src/importers/ImportUtilities.ts
+++ b/packages/eyeglass/src/importers/ImportUtilities.ts
@@ -7,6 +7,7 @@ import { SassImplementation } from "../util/SassImplementation";
 import { Config } from "../util/Options";
 import { isPresent, Dict } from "../util/typescriptUtils";
 import { ImportedFile } from "./ImporterFactory";
+import heimdall = require("heimdalljs");
 
 type ImportContext = AsyncContext & {eyeglass: {imported: Dict<boolean>}};
 
@@ -29,8 +30,13 @@ export default class ImportUtilities {
       }
     });
   }
-  static createImporter(importer: AsyncImporter): AsyncImporter {
-    return function (uri, prev, done) {
+  static createImporter(name: string, importer: AsyncImporter): AsyncImporter {
+    return function (uri, prev, doneImporting) {
+      let importTimer = heimdall.start(`eyeglass:import:${name}`);
+      let done: typeof doneImporting = (data): void => {
+        importTimer.stop();
+        doneImporting(data);
+      };
       uri = URI.web(uri);
       prev = URI.system(prev);
       importer.call(this, uri, prev, done);

--- a/packages/eyeglass/src/importers/ModuleImporter.ts
+++ b/packages/eyeglass/src/importers/ModuleImporter.ts
@@ -73,7 +73,7 @@ const ModuleImporter: ImporterFactory = function (eyeglass, sass, options, fallb
   let includePaths = options.includePaths;
   let root = options.eyeglass.root;
 
-  return ImportUtilities.createImporter(function(uri, prev, done) {
+  return ImportUtilities.createImporter("module", function(uri, prev, done) {
     let importUtils = new ImportUtilities(eyeglass, sass, options, fallbackImporter, this);
     let isRealFile = existsSync(prev);
     // pattern to match moduleName/relativePath

--- a/packages/eyeglass/src/types/heimdalljs.d.ts
+++ b/packages/eyeglass/src/types/heimdalljs.d.ts
@@ -4,12 +4,15 @@ interface Stats {
 interface StatsSchema<T> {
   new (): T;
 }
-export class Cookie {
-  readonly stats: Stats;
+export class Cookie<StatsType = Stats> {
+  readonly stats: StatsType;
   stop(): void;
   resume(): void;
 }
-export function start(name: string): Cookie;
+export function start<
+  Schema extends object = Stats
+>(name: string, Schema?: StatsSchema<Schema>): Cookie<Schema>;
+
 export function node<Return, Context = undefined>(
   name: string,
   callback: (this: Context, stats: Stats) => Return | Promise<Return>,
@@ -21,3 +24,7 @@ export function node<Return, Schema extends object, Context = undefined>(
   callback: (this: Context, stats: Schema) => Return | Promise<Return>,
   context?: Context
 ): Promise<Return>;
+
+export function hasMonitor(name: string): boolean;
+export function registerMonitor(name: string, Schema: {new (): any}): void;
+export function statsFor<Schema = Stats>(name: string): Schema;

--- a/packages/eyeglass/src/types/heimdalljs.d.ts
+++ b/packages/eyeglass/src/types/heimdalljs.d.ts
@@ -1,0 +1,23 @@
+interface Stats {
+  [k: string]: number;
+}
+interface StatsSchema<T> {
+  new (): T;
+}
+export class Cookie {
+  readonly stats: Stats;
+  stop(): void;
+  resume(): void;
+}
+export function start(name: string): Cookie;
+export function node<Return, Context = undefined>(
+  name: string,
+  callback: (this: Context, stats: Stats) => Return | Promise<Return>,
+  context?: Context
+): Promise<Return>;
+export function node<Return, Schema extends object, Context = undefined>(
+  name: string,
+  schema: StatsSchema<Schema>,
+  callback: (this: Context, stats: Schema) => Return | Promise<Return>,
+  context?: Context
+): Promise<Return>;

--- a/packages/eyeglass/tsconfig.json
+++ b/packages/eyeglass/tsconfig.json
@@ -25,6 +25,7 @@
         "target": "es5",
         "sourceMap": true,
         "paths": {
+          "*": ["types/*"],
             "node-sass": ["../@types/node-sass"]
         }
     },


### PR DESCRIPTION
Instrument eyeglass and broccoli-eyeglass for performance metrics gathering with heimdalljs.

This introduces metrics collections for the following:

#### Always enabled
* `eyeglass:broccoli:build:compileTree:<directory>` - Each broccoli tree that gets compiled by broccoli-eyeglass.
  * Additional Metrics collected per tree:
    * `cacheMissCount` - how many sass files had to be recompiled
    * `cacheHitCount`- how many sass files were cached
    * `numSassFiles` - the number of sass files.
    * `nodeSassTime` - The time node-sass reports spending on compilation (includes waiting in the libuv worker queue).
    * `importCount` - The number of `@import` statements encountered.
    * `uniqueImportCount` - The number of `@import` statements that couldn't be deduplicated.
  * eyeglass:broccoli:build:invalidation - the cost of invalidating cache results based on what's changed since the last build.
* eyeglass:instantiation - The cost of instantiation and module creation.
  * `eyeglass:modules` - eyeglass modules creation during instantiation
    * `eyeglass:modules:discovery` - discovery of eyeglass modules within npm modules.
    * `eyeglass:modules:resolution` - resolving transitive eyeglass modules into a single version.

#### Conditionally enabled

When the environment variable `EYEGLASS_PERF_DEBUGGING` is set to a non-empty string additional perf metrics are collected. These incur performance overhead and can bloat the
heimdall data returned.

Heimdall nodes are added for:
* eyeglass:import:module - the cost of module import (most imports are these)
  * eyeglass:import:assets - the cost of asset importing (delegated from the module importer)
    * eyeglass:import:fs - the cost of fs importing (delegated from the asset importer)

A heimdall monitor named `sassFns` is enabled causing stats to be collected against the broccoli-eyeglass tree node:
* The key is the sass function name that was invoked and the value is an object with a `count` and a `time` similar to how the heimdall `fs` monitor works. these times are collected with nanosecond precision. This only monitors sass functions implemented in js.
