### PR TITLE
[eyeglass] Optimize asset registration

### DIFF
--- a/packages/eyeglass/sass/assets.scss
+++ b/packages/eyeglass/sass/assets.scss
@@ -18,6 +18,13 @@ $eg-registered-assets: () !default;
 
   @return $uri;
 }
+@function eyeglass-normalize-assets($assets) {
+  @if function-exists(-eyeglass-normalize-assets) {
+    @return -eyeglass-normalize-assets($assets);
+  }
+
+  @return $assets;
+}
 // Registers many assets for a module at once.
 // @param $module string The name of the module to which these assets belong.
 // @param $url the source url of the asset. This is what is passed to asset-url().
@@ -54,10 +61,15 @@ $eg-registered-assets: () !default;
 // @param $assets map<string => map> maps source urls to the asset information
 //   as described in the docs for `$eg-registered-assets` above.
 @function asset-register-all($module, $assets) {
-  // iterate through the given assets and register
-  @each $key, $asset in $assets {
-    $trash: asset-register($module, $key, map-get($asset, filepath), map-get($asset, uri));
+  $assets: eyeglass-normalize-assets($assets);
+  $mod-assets: map-get($eg-registered-assets, $module);
+  @if ($mod-assets) {
+    $mod-assets: map-merge($mod-assets, $assets);
   }
+  @else {
+    $mod-assets: $assets;
+  }
+  $eg-registered-assets: map-merge($eg-registered-assets, ($module: $mod-assets)) !global;
   @return null;
 }
 

--- a/packages/eyeglass/src/functions/normalize-uri.ts
+++ b/packages/eyeglass/src/functions/normalize-uri.ts
@@ -1,6 +1,6 @@
 import { URI } from  "../util/URI";
 import { IEyeglass } from "../IEyeglass";
-import { SassImplementation, isSassString, typeError } from "../util/SassImplementation";
+import { SassImplementation, isSassString, typeError, isSassMap } from "../util/SassImplementation";
 import { SassFunctionCallback, FunctionDeclarations } from "node-sass";
 import * as nodeSass from "node-sass";
 const IS_WINDOWS = /win32/.test(require("os").platform());
@@ -28,18 +28,76 @@ const normalizeURI = function(_eyeglass: IEyeglass, sass: SassImplementation): F
   };
 
   if (IS_WINDOWS || process.env.EYEGLASS_NORMALIZE_PATHS) {
-    methods["-eyeglass-normalize-uri($uri, $type: web)"] = function($uri: nodeSass.types.Value, $type: nodeSass.types.Value, done: SassFunctionCallback) {
+    let $web = nodeSass.types.String("web");
+    let $system = nodeSass.types.String("system");
+    let egNormalizeUri = function($uri: nodeSass.types.Value, $type: nodeSass.types.Value): nodeSass.types.String {
       if (!isSassString(sass, $type)) {
-        return done(typeError(sass, "string", $type));
+        throw typeError(sass, "string", $type);
       }
       if (!isSassString(sass, $uri)) {
-        return done(typeError(sass, "string", $uri));
+        throw typeError(sass, "string", $uri);
       }
       let type = $type.getValue() as "web" | "system" | "preserve" | "restore";
       let uri = $uri.getValue();
       // normalize the uri for the given type
       uri = URI[type](uri);
-      done(sass.types.String(uri));
+      return sass.types.String(uri);
+    };
+    methods["-eyeglass-normalize-uri($uri, $type: web)"] = function($uri: nodeSass.types.Value, $type: nodeSass.types.Value, done: SassFunctionCallback) {
+      try {
+        done(egNormalizeUri($uri, $type));
+      } catch (e) {
+        done(e);
+      }
+    };
+    methods["-eyeglass-normalize-assets($assets)"] = function($assets: nodeSass.types.Value, done: SassFunctionCallback): void {
+      if (!isSassMap(sass, $assets)) {
+        done($assets);
+        return;
+      }
+      let size = $assets.getLength();
+      let $newAssets = new sass.types.Map(size);
+      for (let i = 0; i < size; i++) {
+        let $url = $assets.getKey(i);
+        if (isSassString(sass, $url)) {
+          $url = egNormalizeUri($url, $web);
+        }
+        $newAssets.setKey(i, $url)
+        let $assetProps = $assets.getValue(i);
+        if (isSassMap(sass, $assetProps)) {
+          let numAssetProps = $assetProps.getLength();
+          let $newAssetProps = new sass.types.Map(numAssetProps);
+          for (let pi = 0; pi < numAssetProps; pi++) {
+            let $propName = $assetProps.getKey(pi);
+            let $propValue = $assetProps.getValue(pi);
+            $newAssetProps.setKey(pi, $propName);
+            if (isSassString(sass, $propName)) {
+              let propName = $propName.getValue();
+              try {
+                switch (propName) {
+                  case "filepath":
+                    $newAssetProps.setValue(pi, egNormalizeUri($propValue, $system));
+                    break;
+                  case "uri":
+                    $newAssetProps.setValue(pi, egNormalizeUri($propValue, $web));
+                    break;
+                  default:
+                    $newAssetProps.setValue(pi, $propValue);
+                }
+              } catch(e) {
+                done(e);
+                return;
+              }
+            } else {
+              $newAssetProps.setValue(pi, $propValue);
+            }
+          }
+          $newAssets.setValue(i, $newAssetProps);
+        } else {
+          $newAssets.setValue(i, $assetProps);
+        }
+      }
+      done($newAssets);
     };
   }
 


### PR DESCRIPTION
`map-merge` is slow for maps with many keys. This patch:

* Changes the asset importer to generate Sass code that invokes `@include asset-register-all()` instead of many calls to `@include asset-register()`.
* Changes asset-register-all() to no longer delegate to `asset-register()` for each asset. Instead it passes all the assets to js where the url normalization is done in a single pass over the asset data structure.
* On non-windows machines, asset url normalization is completely skipped. This makes asset registration a single map-merge onto a map with low cardinality.
