### PR TITLE
[broccoli-eyeglass] Optimize Sass concurrency.

### DIFF
--- a/packages/broccoli-eyeglass/package.json
+++ b/packages/broccoli-eyeglass/package.json
@@ -57,6 +57,7 @@
     "node-sass": "^4.11.0",
     "rsvp": "^4.8.3",
     "sync-disk-cache": "^1.3.2",
+    "systeminformation": "^4.1.4",
     "walk-sync": "^0.3.1"
   },
   "engines": {

--- a/packages/broccoli-eyeglass/src/broccoli_sass_compiler.ts
+++ b/packages/broccoli-eyeglass/src/broccoli_sass_compiler.ts
@@ -19,7 +19,7 @@ import heimdall = require("heimdalljs");
 import {statSync} from "fs";
 import {determineOptimalConcurrency} from "./concurrency";
 
-const concurrency = determineOptimalConcurrency();
+const concurrency = RSVP.resolve(determineOptimalConcurrency());
 
 const FSTreeFromEntries = FSTree.fromEntries;
 const debug = debugGenerator("broccoli-eyeglass");

--- a/packages/broccoli-eyeglass/src/concurrency.ts
+++ b/packages/broccoli-eyeglass/src/concurrency.ts
@@ -1,0 +1,92 @@
+import debugGenerator = require("debug");
+import systeminformation = require("systeminformation");
+
+const concurrencyDebug = debugGenerator("broccoli-eyeglass:concurrency");
+
+export const DEFAULT_CONCURRENCY = Number(process.env.SASS_JOBS) || Number(process.env.JOBS) || 4;
+
+export function determineOptimalConcurrency(): Promise<number> {
+  let sassConcurrency = Number(process.env.SASS_JOBS) || Number(process.env.JOBS) || undefined;
+  let threadpoolSize = Number(process.env.UV_THREADPOOL_SIZE) || undefined;
+  if (sassConcurrency) {
+    concurrencyDebug(
+      "%d concurrent sass jobs have been requested.",
+      sassConcurrency);
+  } else {
+    concurrencyDebug("Neither SASS_JOBS nor JOBS is set in this environment");
+  }
+  if (threadpoolSize) {
+    concurrencyDebug(
+      "UV threadpool size is explicitly set to %d.",
+      threadpoolSize);
+  } else {
+    concurrencyDebug("UV_THREADPOOL_SIZE is not set in this environment");
+  }
+
+  // It does no good to have more sass concurrency than the threadpool size.
+  if (threadpoolSize && sassConcurrency && threadpoolSize < sassConcurrency) {
+    concurrencyDebug(
+      "Capping sass concurrency to threadpool size of %d.",
+      threadpoolSize);
+    sassConcurrency = threadpoolSize;
+  }
+  // Exit early, the user is in control.
+  if (threadpoolSize && sassConcurrency) {
+    concurrencyDebug("Using user-specified concurrency values.");
+    return Promise.resolve(sassConcurrency);
+  }
+
+  // We don't have a threadpool size, we need to set one based on our cores.
+  // testing shows that maximum throughput is achieved by using the number
+  // of physical cores of the machine.
+  return systeminformation.cpu().then((result) => {
+    let {cores, physicalCores} = result;
+    concurrencyDebug("There are %d physical cores in this machine", physicalCores)
+    if (threadpoolSize && threadpoolSize <= cores) {
+      // sassConcurrency is undefined if threadpoolSize is defined.
+      concurrencyDebug(
+        "Using all %d available threads for sass compilation.",
+        threadpoolSize);
+      return threadpoolSize;
+    }
+    if (sassConcurrency && sassConcurrency > cores) {
+      concurrencyDebug(
+        "%d sass jobs requested exceeds the %d cores in this machine," +
+        " Ignoring user request.",
+        sassConcurrency,
+        cores);
+      sassConcurrency = undefined;
+    }
+
+    if (sassConcurrency && sassConcurrency > physicalCores) {
+      // Print a warning if physicalCores < sassConcurrency <= cores
+      // But pretend the user knows what they're doing.
+      concurrencyDebug(
+        "WARNING: %d sass jobs requested exceeds the %d physical cores," +
+        " this is probably slower as a result.",
+        sassConcurrency,
+        physicalCores)
+    }
+
+    if (!sassConcurrency) {
+      concurrencyDebug(
+        "Setting concurrency to the number of physical cores (%d).",
+        physicalCores);
+      sassConcurrency = physicalCores;
+    }
+    // The threadpool size is unset.
+    // Set the threadpool size to match the requested concurrency.
+    // unless this would shrink the default size of the pool
+    if (sassConcurrency > 4) {
+      concurrencyDebug(
+        "Setting UV_THREADPOOL_SIZE to the concurrency level (%d).",
+        sassConcurrency);
+      process.env.UV_THREADPOOL_SIZE = sassConcurrency.toString();
+    } else {
+      concurrencyDebug(
+        "Leaving UV_THREADPOOL_SIZE unset (the default is 4). " +
+        "Sass will not use all available threads.");
+    }
+    return sassConcurrency;
+  });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -11356,6 +11356,11 @@ sync-disk-cache@^1.3.2:
     rimraf "^2.2.8"
     username-sync "^1.0.2"
 
+systeminformation@^4.1.4:
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/systeminformation/-/systeminformation-4.1.4.tgz#39530317c82866dc0d6f1e6da76da6c2532d4e19"
+  integrity sha512-kYwSfnSUVjMiw+MHRZkokWx7q8v3ZaanZky40NNxpSfMmAw8kOQbEwmNiAqBa9ynFJX9G+OGWx2wRF72XdWmPQ==
+
 table@^5.2.3:
   version "5.2.3"
   resolved "https://registry.yarnpkg.com/table/-/table-5.2.3.tgz#cde0cc6eb06751c009efab27e8c820ca5b67b7f2"


### PR DESCRIPTION
Empirical testing shows that Sass compilation performance is optimal when the number of physical cores is used for concurrent compilation. In this patch, I use `systeminformation` to get access to the number of physical cores because node only exposes the number of cores which includes virtual (hypervisor) cores.

Environment Variables:
* `JOBS` - a general setting for concurrency in an ember-cli build.
* `SASS_JOBS` - will override the number specified by `JOBS`. If set to `auto` it will override
  the value of `JOBS` and behave as if neither of them were set.
* `UV_THREADPOOL_SIZE` - controls the number of threads in the uv threadpool. When `UV_THREADPOOL_SIZE` is unset, we will set it to the number of concurrent sass jobs we decide to use as long as this is not smaller than the default of 4. When `UV_THREADPOOL_SIZE` is set, it will cap the number of concurrent sass jobs we will perform.
* `DEBUG` - When debugging `broccoli-eyeglass:concurrency`, you will see detailed logging explaining how the concurrency level is is determined.

The number of Sass jobs requested is overridden or ignored when it is clearly going to just cause jobs to spend longer in the uv queue and inflate the compilation times or result in obviously worse performance.
