### PR TITLE
fix: Process dependency conflicts.

### DIFF
--- a/packages/eyeglass/src/Eyeglass.ts
+++ b/packages/eyeglass/src/Eyeglass.ts
@@ -128,8 +128,14 @@ const VERSION_WARNINGS_ISSUED: Dict<boolean> = {};
 function checkDependencyConflicts(this: IEyeglass): void {
   let conflicts = this.modules.issues.dependencies.versions;
   let strictMode = this.options.eyeglass.strictModuleVersions;
+  let deprecatedWarn = false;
   if (typeof strictMode === "undefined") {
     strictMode = "warn";
+  }
+  // XXX Remove prior to next major release.
+  if (strictMode === true) {
+    strictMode = "warn";
+    deprecatedWarn = true;
   }
   for (let conflict of conflicts) {
     let message = `Version conflict for eyeglass module '${conflict.name}': ${conflict.requested.version} was requested but it was globally resolved to ${conflict.resolved.version}.`;
@@ -138,6 +144,9 @@ function checkDependencyConflicts(this: IEyeglass): void {
     } else if (strictMode === "warn") {
       if (!VERSION_WARNINGS_ISSUED[message]) {
         console.error(`WARNING: ${message}`);
+        if (deprecatedWarn) {
+          console.error("WARNING: Because strictModuleVersions is true, the previous warning will become an error in the next major release. Consider setting strictModuleVersions to 'warn' for now.");
+        }
         VERSION_WARNINGS_ISSUED[message] = true;
       }
     } else if (strictMode === true) {

--- a/packages/eyeglass/src/modules/EyeglassModules.ts
+++ b/packages/eyeglass/src/modules/EyeglassModules.ts
@@ -265,7 +265,10 @@ export default class EyeglassModules {
     *
     * @returns {String} the module hierarchy
     */
-  getGraph(tree: ModuleBranch): string {
+  getGraph(tree?: ModuleBranch): string {
+    if (!tree) {
+      tree = this.tree;
+    }
     let hierarchy = getHierarchy(tree);
     hierarchy.label = this.getDecoratedRootName();
     return archy(hierarchy);

--- a/packages/eyeglass/test/fixtures/EyeglassModules/has_conflicting_versions/expected.issues
+++ b/packages/eyeglass/test/fixtures/EyeglassModules/has_conflicting_versions/expected.issues
@@ -3,10 +3,10 @@
     "versions": [
       {
         "name": "module_b",
-        "left": {
+        "requested": {
           "version": "1.0.0"
         },
-        "right": {
+        "resolved": {
           "version": "2.0.0"
         }
       }

--- a/packages/eyeglass/test/test_utils.js
+++ b/packages/eyeglass/test/test_utils.js
@@ -39,7 +39,7 @@ describe("utilities", function () {
 
       assert(versionIssues.length, "discovery found errors");
       assert.equal(versionIssues[0].name, "conflict_module");
-      assert.notEqual(versionIssues[0].left.version, versionIssues[0].right.version);
+      assert.notEqual(versionIssues[0].requested.version, versionIssues[0].resolved.version);
     });
 
   it("loads a package.json for an eyeglass module", function (done) {


### PR DESCRIPTION
Eyeglass was designed to raise errors or produce warnings depending on the value of the `strictModuleVersions` option. However it seems like we never actually issued that warning or error if it was supposed to have been issued.