### PR TITLE
Ignore duplicate modules

### DIFF
--- a/packages/broccoli-eyeglass/test/test_eyeglass_plugin.js
+++ b/packages/broccoli-eyeglass/test/test_eyeglass_plugin.js
@@ -14,6 +14,7 @@ const fs = require("fs");
 const rimraf = require("rimraf");
 const glob = require("glob");
 const EyeglassCompiler = require("../lib/index");
+const resetGlobalEyeglassCaches = require("eyeglass").resetGlobalCaches;
 const SyncDiskCache = require("sync-disk-cache");
 const walkSync = require("walk-sync");
 const os = require("os");
@@ -87,6 +88,7 @@ describe("EyeglassCompiler", function() {
     } else {
       delete process.env.CI;
     }
+    resetGlobalEyeglassCaches();
   });
 
   function assertEqualDirs(actualDir, _expectedDir) {
@@ -1334,6 +1336,7 @@ describe("EyeglassCompiler", function() {
 
         delete require.cache[fs.realpathSync(eyeglassModule.path("eyeglass-exports.js"))];
         delete require.cache[fs.realpathSync(eyeglassModule.path("lib/foo.js"))];
+        resetGlobalEyeglassCaches();
 
         yield builders[1].build();
 
@@ -1426,6 +1429,7 @@ describe("EyeglassCompiler", function() {
 
         delete require.cache[fs.realpathSync(eyeglassModule.path("eyeglass-exports.js"))];
         delete require.cache[fs.realpathSync(eyeglassModule.path("lib/foo.js"))];
+        resetGlobalEyeglassCaches();
 
         yield builders[1].build();
 

--- a/packages/eyeglass/src/modules/EyeglassModule.ts
+++ b/packages/eyeglass/src/modules/EyeglassModule.ts
@@ -157,8 +157,8 @@ interface IEyeglassModule {
   sassDir?: string;
 }
 
-function isModuleReference(mod: {path?: string}): mod is ModuleReference {
-  return typeof mod === "object" && !! mod["path"];
+export function isModuleReference(mod: unknown): mod is ModuleReference {
+  return typeof mod === "object" && mod !== null && typeof (<ModuleReference>mod).path === "string";
 }
 
 export default class EyeglassModule implements IEyeglassModule, EyeglassModuleExports {
@@ -281,6 +281,20 @@ export default class EyeglassModule implements IEyeglassModule, EyeglassModuleEx
     */
   static isEyeglassModule(pkg: PackageJson | undefined | null): boolean {
     return !!(isPresent(pkg) && includes(pkg.keywords, EYEGLASS_KEYWORD));
+  }
+
+  hasModulePath(path: string): boolean {
+    if (this.path === path) {
+      return true;
+    }
+    let keys = this.dependencies ? Object.keys(this.dependencies) : [];
+    for (let depKey of keys) {
+      let dep = this.dependencies[depKey];
+      if (dep instanceof EyeglassModule && dep.hasModulePath(path)) {
+        return true;
+      }
+    }
+    return false;
   }
 }
 


### PR DESCRIPTION
BREAKING CHANGE: this fix might change the resolved version of an eyeglass module that is both a direct dependency, a transitive dependency, and/or for which a manual module of the same name is provided.

Manual module declarations are added as direct dependencies to the root. But if the manual module was already in the module tree as a transitive dependency and a direct dependency at different versions, then adding the manual module of the transitive dependency would overwrite the direct dependency. It was never the intent for manual modules to be used to replace discovered modules, so this behavior is considered a bug which has now been fixed.

This change has three effects:

1. Manual modules that are path references to a module discovered in the
   node module tree are no longer added as direct dependencies of the
   root module.
2. Manual modules that have the same name as a direct dependency of the
   root module from the package.json dependencies are ignored.
3. If multiple manual modules are added which have the same name, the
   first module of the same name in that list will be added to the root
   module. (Previously, the last module in the list would win.)