### PR TITLE
Non-sass files should be preserved (instead of discarded).

### DIFF
--- a/packages/ember-cli-eyeglass/package.json
+++ b/packages/ember-cli-eyeglass/package.json
@@ -49,6 +49,7 @@
     "broccoli"
   ],
   "dependencies": {
+    "broccoli-debug": "^0.6.5",
     "broccoli-eyeglass": "^6.0.1",
     "broccoli-funnel": "^2.0.1",
     "broccoli-merge-trees": "^3.0.0",

--- a/packages/ember-cli-eyeglass/src/types/broccoli-funnel.d.ts
+++ b/packages/ember-cli-eyeglass/src/types/broccoli-funnel.d.ts
@@ -1,5 +1,4 @@
-export = index;
-declare class index {
+declare class Funnel {
   constructor(inputNode: any, _options: any);
   destDir: any;
   count: any;
@@ -16,3 +15,10 @@ declare class index {
   read(readTree: any): any;
   shouldLinkRoots(): any;
 }
+
+export = funnel;
+declare function funnel(inputNode: any, options: any): Funnel;
+declare namespace funnel {
+  const Funnel: Funnel;
+}
+

--- a/private-packages/eyeglass-test-app/.gitignore
+++ b/private-packages/eyeglass-test-app/.gitignore
@@ -23,3 +23,4 @@
 /.node_modules.ember-try/
 /bower.json.ember-try
 /package.json.ember-try
+/DEBUG/

--- a/private-packages/eyeglass-test-app/app/index.html
+++ b/private-packages/eyeglass-test-app/app/index.html
@@ -11,6 +11,7 @@
 
     <link integrity="" rel="stylesheet" href="{{rootURL}}assets/vendor.css">
     <link integrity="" rel="stylesheet" href="{{rootURL}}assets/eyeglass-test-app.css">
+    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/unprocessed.css">
 
     {{content-for "head-footer"}}
   </head>

--- a/private-packages/eyeglass-test-app/app/styles/unprocessed.css
+++ b/private-packages/eyeglass-test-app/app/styles/unprocessed.css
@@ -1,0 +1,3 @@
+.styled-by-css {
+  color: orange;
+}

--- a/private-packages/eyeglass-test-app/app/templates/application.hbs
+++ b/private-packages/eyeglass-test-app/app/templates/application.hbs
@@ -1,5 +1,6 @@
 <h2 class="warning"> Some Warning! </h2>
 <h2 class="error"> Some Error! </h2>
+<h3 class="styled-by-css"> This is orange because of an unprocessed css file.</h3>
 
 <nav>
   {{#link-to 'index'}}Home{{/link-to}}

--- a/private-packages/eyeglass-test-app/tests/acceptance/eyeglass-test.js
+++ b/private-packages/eyeglass-test-app/tests/acceptance/eyeglass-test.js
@@ -110,4 +110,10 @@ module('Acceptance | eyeglass', function(hooks) {
     let text = await fetch('/engines-dist/lazy-test-addon/assets/engine.css').then(req => req.text());
     assert.contains('.lazy', text);
   });
+
+  test('/assets/unprocessed.css exists', async function(assert) {
+    let text = await (await fetch('/assets/unprocessed.css')).text();
+
+    assert.contains('.styled-by-css', text);
+  });
 });

--- a/private-packages/eyeglass-test-app/tests/index.html
+++ b/private-packages/eyeglass-test-app/tests/index.html
@@ -13,6 +13,7 @@
     <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
     <link rel="stylesheet" href="{{rootURL}}assets/eyeglass-test-app.css">
     <link rel="stylesheet" href="{{rootURL}}assets/eager.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/unprocessed.css">
     <link rel="stylesheet" href="{{rootURL}}assets/test-support.css">
 
     {{content-for "head-footer"}}


### PR DESCRIPTION
`ember-cli-eyeglass` was discarding any files in the `{app,addon}/styles` directories that didn't have a sass extension. Per the ember documentation, those files should be left alone and just moved to the `assets` directory. This is what the default behavior does when there's no css preprocessors registered with ember-cli.

Note: eyeglass still doesn't respect the output path configuration, that should be done in a different patch for all of the sass and non-sass css files.