### PR TITLE
Should execute after ember-css-modules

### DIFF
--- a/packages/ember-cli-eyeglass/package.json
+++ b/packages/ember-cli-eyeglass/package.json
@@ -73,5 +73,10 @@
   "volta": {
     "node": "10.18.1",
     "yarn": "1.22.5"
+  },
+  "ember-addon": {
+    "after": [
+      "ember-css-modules"
+    ]
   }
 }


### PR DESCRIPTION
ember-css-modules should run its build step before ember-cli-eyeglass. This allows for CSS Modules intermediate builds to work nicely with Eyeglass. (See https://github.com/salsify/ember-css-modules/blob/master/docs/PREPROCESSORS.md)